### PR TITLE
Update front-end

### DIFF
--- a/desk/app/gs/index.hoon
+++ b/desk/app/gs/index.hoon
@@ -1,5 +1,5 @@
 /-  *gs
-|=  [bol=bowl:gall =store =objs input-reset=? selected-desks=(set @t)]
+|=  [bol=bowl:gall =store =objs input-reset=? selected-desks=(set @t) edit-mode=?]
 |^  ^-  manx
 ::
 ;html
@@ -11,6 +11,15 @@
   ;body
     ;h1(class "title"): Global Store
     ;+  gs-form
+    ;div
+      ;button(event "/click/select-all-desks"): Select All
+      ;button(event "/click/hide-all-desks"): Hide All
+      ;button
+        =class  ?:(edit-mode "edit-button-on" "")
+        =event  "/click/toggle-edit-mode"
+        ;+  ;/  "Edit"
+      ==
+    ==
     ;+  all-desks
   ==
 ==
@@ -71,7 +80,18 @@
       ;div
         =class  "kv-item"
         =key  "{(path key)}"
-        ;div(class "kv-name"): {name}
+        ;div
+          =class  "kv-item-top"
+          ;div(class "kv-name"): {name}
+          ;+  ?.  edit-mode  ;div;
+            ;button
+              =id  <(path key)>
+              =class  "delete-button"
+              =event  "/click/delete"
+              =return  "/target/id"
+              ;+  ;/  "✖"
+            ==
+        ==
         ;div
           ;div: {<p.val>}
           ;div: {<p.q.val>}

--- a/desk/app/gs/index.hoon
+++ b/desk/app/gs/index.hoon
@@ -67,7 +67,7 @@
     ;*  %+  turn  kvs
       |=  [key=key hax=@uvI]
       =/  val=cage  (~(got by objs) hax)
-      =/  name=tape  ?~(key "" ?~(t.key "" (trip i.t.key)))
+      =/  name=tape  ?~(key "" ?~(t.key "" <(path t.key)>))
       ;div
         =class  "kv-item"
         =key  "{(path key)}"
@@ -102,7 +102,7 @@
     acc
   ?.  &(?=(^ p.i.sto) (~(has in selected-desks) i.p.i.sto))
     $(sto t.sto)
-  =/  nacc=(list [@t (list (pair key @uvI))])
+  =.  acc
     |-
     ?~  sto  !!
     ?~  acc
@@ -110,6 +110,6 @@
     ?:  =(desk.i.acc i.p.i.sto)
       [[desk.i.acc [i.sto kvs.i.acc]] $(acc t.acc)]
     [i.acc $(acc t.acc)]
-  $(sto t.sto, acc nacc)
+  $(sto t.sto, acc acc)
 ::
 --

--- a/desk/app/gs/style.hoon
+++ b/desk/app/gs/style.hoon
@@ -49,6 +49,7 @@ label {
   flex-wrap: wrap;
 }
 .desks-container {
+  width: 100%;
   display: flex;
   flex-direction: row;
   justify-content: center;
@@ -56,6 +57,7 @@ label {
   flex-wrap: wrap;
 }
 .desk {
+  width: 20rem;
   margin: 1rem;
   border-radius: 1rem;
   background-color: var(--light-color-two);
@@ -75,16 +77,32 @@ label {
 .desk-selector:hover {
   transform: scale(1.03);
 }
+.kv-table {
+  max-height: 20rem;
+  overflow: auto;
+}
 .kv-item {
+  max-width: 15rem;
   margin: 1.5rem;
   padding: 0.9rem;
   border: 1px solid var(--dark-color-two);
   border-radius: 0.7rem;
   display: flex;
   flex-direction: column;
+  word-wrap: break-word;
 }
 .kv-name {
   font-size: 1.2rem;
   margin-bottom: 0.5rem;
+}
+@media only screen and (max-width: 600px) {
+  .gs-form {
+    padding: 1.5rem;
+    flex-direction: column;
+    flex-wrap: unset;
+  }
+  .kv-table {
+    max-height: unset;
+  }
 }
 '''

--- a/desk/app/gs/style.hoon
+++ b/desk/app/gs/style.hoon
@@ -36,6 +36,15 @@ label {
   display: flex;
   flex-direction: column;
 }
+.edit-button-on {
+  background-color: orange;
+}
+.delete-button {
+  padding-inline: 0.4rem;
+  padding-block: 0.2rem;
+  margin: 0;
+  border-radius: 1rem;
+}
 .title {
   border-bottom: 0.2rem solid var(--dark-color-one);
 }
@@ -90,6 +99,12 @@ label {
   display: flex;
   flex-direction: column;
   word-wrap: break-word;
+}
+.kv-item-top {
+  display: flex;
+  flex-direction: row;
+  justify-content: space-between;
+  align-items: flex-start;
 }
 .kv-name {
   font-size: 1.2rem;


### PR DESCRIPTION
There's some heavier refactoring in the agent with this update. I moved put and del into their own arms so that both the gs-action and json front-end cases could use the same code. And I made it so that the front-end state is separate from versioned state — it is not included in on-save and bunted in on-load. I don't think the front-end state needs to persist in the same way as the back-end, so this makes it easier to change things in the ui. 

I also added select all and hide all desk buttons, and an edit mode button which renders delete buttons on each item, so you can delete entries now.

And I fixed the input processing, so the mark doesn't just set itself as %noun anymore, and the value is parsed properly.